### PR TITLE
Исправление ошибки линковки

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=StringUtils
-version=1.2.5
+version=1.2.6
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Bunch of converting functions for string data

--- a/src/utils/convert.h
+++ b/src/utils/convert.h
@@ -4,7 +4,7 @@
 namespace sutil {
 
 // быстрое возведение 10 в степень
-uint32_t getPow10(uint8_t value) {
+inline uint32_t getPow10(uint8_t value) {
     switch (value) {
         case 0:
             return 0;
@@ -31,7 +31,7 @@ uint32_t getPow10(uint8_t value) {
 }
 
 // быстрый целочисленный логарифм 10 (длина числа в кол-ве символов)
-uint8_t getLog10(const uint32_t& value) {
+inline uint8_t getLog10(const uint32_t& value) {
     switch (value) {
         case 0 ... 9:
             return 1;
@@ -57,7 +57,7 @@ uint8_t getLog10(const uint32_t& value) {
     return 1;
 }
 
-uint8_t getLog10(const int32_t& value) {
+inline uint8_t getLog10(const int32_t& value) {
     return getLog10((value < 0) ? (uint32_t)(-value) : (uint32_t)value);
 }
 
@@ -67,7 +67,7 @@ uint8_t getLog10(const int32_t& value) {
  * @param str строка
  * @return uint16_t длина
  */
-uint16_t strlenRu(const char* str) {
+inline uint16_t strlenRu(const char* str) {
     uint16_t count = 0;
     while (*str) {
         if ((*str & 0xc0) != 0x80) count++;
@@ -82,7 +82,7 @@ uint16_t strlenRu(const char* str) {
  * @param val
  * @return uint8_t
  */
-uint8_t intLen(const int32_t& val) {
+inline uint8_t intLen(const int32_t& val) {
     return getLog10(val) + (val < 0 ? 1 : 0);
 }
 
@@ -93,7 +93,7 @@ uint8_t intLen(const int32_t& val) {
  * @param dec
  * @return uint8_t
  */
-uint8_t floatLen(const double& val, uint8_t dec) {
+inline uint8_t floatLen(const double& val, uint8_t dec) {
     return intLen((int32_t)val) + (dec ? (dec + 1) : 0);
 }
 
@@ -149,7 +149,7 @@ T strToInt_P(const char* str, uint8_t len = 0) {
  * @param dec кол-во знаков после точки
  * @return uint8_t длина полученной строки
  */
-uint8_t floatToStr(double val, char* buf, uint8_t dec = 2) {
+inline uint8_t floatToStr(double val, char* buf, uint8_t dec = 2) {
     dtostrf(val, dec + 2, dec, buf);
     return floatLen(val, dec);
 }
@@ -161,7 +161,7 @@ uint8_t floatToStr(double val, char* buf, uint8_t dec = 2) {
  * @param len длина числа в строке (не указывать, если строка заканчивается '\0')
  * @return uint32_t
  */
-uint32_t strToIntHex(const char* str, int8_t len = -1) {
+inline uint32_t strToIntHex(const char* str, int8_t len = -1) {
     uint32_t v = 0;
     while (*str && len) {
         v <<= 4;
@@ -178,7 +178,7 @@ uint32_t strToIntHex(const char* str, int8_t len = -1) {
  * @param sym символ utf-8
  * @return uint8_t 0 если некорректный символ или продолжение предыдущего
  */
-uint8_t charSize(char sym) {
+inline uint8_t charSize(char sym) {
     if ((sym & 0x80) == 0x00) return 1;
     else if ((sym & 0xE0) == 0xC0) return 2;
     else if ((sym & 0xF0) == 0xE0) return 3;
@@ -210,7 +210,7 @@ struct _fdiv10 {
  * @param base основание (DEC, HEX, OCT, BIN)
  * @return uint8_t длина числа
  */
-uint8_t uintToStr(uint32_t n, char* buf, uint8_t base = DEC) {
+inline uint8_t uintToStr(uint32_t n, char* buf, uint8_t base = DEC) {
     char* p = buf;
     if (base == DEC) {
         do {
@@ -246,7 +246,7 @@ uint8_t uintToStr(uint32_t n, char* buf, uint8_t base = DEC) {
  * @param base основание (DEC, HEX, OCT, BIN)
  * @return uint8_t длина числа
  */
-uint8_t intToStr(int32_t n, char* buf, uint8_t base = DEC) {
+inline uint8_t intToStr(int32_t n, char* buf, uint8_t base = DEC) {
     char* p = buf;
     if (n < 0) *p++ = '-';
     p += uintToStr((n < 0) ? -n : n, p, base);
@@ -262,7 +262,7 @@ uint8_t intToStr(int32_t n, char* buf, uint8_t base = DEC) {
  * @param base основание (DEC, HEX, OCT, BIN)
  * @return uint8_t длина числа
  */
-uint8_t uint64ToStr(uint64_t n, char* buf, uint8_t base = DEC) {
+inline uint8_t uint64ToStr(uint64_t n, char* buf, uint8_t base = DEC) {
     char* p = buf;
     if (base == DEC) {
         do {
@@ -298,7 +298,7 @@ uint8_t uint64ToStr(uint64_t n, char* buf, uint8_t base = DEC) {
  * @param base основание (DEC, HEX, OCT, BIN)
  * @return uint8_t длина числа
  */
-uint8_t int64ToStr(int64_t n, char* buf, uint8_t base = DEC) {
+inline uint8_t int64ToStr(int64_t n, char* buf, uint8_t base = DEC) {
     char* p = buf;
     if (n < 0) *p++ = '-';
     p += uint64ToStr((n < 0) ? -n : n, p, base);
@@ -307,7 +307,7 @@ uint8_t int64ToStr(int64_t n, char* buf, uint8_t base = DEC) {
 }
 
 // конвертация из строки во float
-float strToFloat(const char* s) {
+inline float strToFloat(const char* s) {
     float f = strToInt<int32_t>(s);
     char* d = strchr(s, '.');
     if (d) {
@@ -317,7 +317,7 @@ float strToFloat(const char* s) {
 }
 
 // конвертация из PROGEMEM строки во float
-float strToFloat_P(PGM_P s) {
+inline float strToFloat_P(PGM_P s) {
     float f = strToInt_P<int32_t>(s);
     char* d = strchr(s, '.');
     if (d) {

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -51,22 +51,22 @@ constexpr uint32_t SH32(const char* str) {
 // =====================================================
 
 // хэш строки, выполняется в рантайме. Размер зависит от платформы и соответствует size_t
-size_t hash(const char* str, int16_t len = -1) {
+inline size_t hash(const char* str, int16_t len = -1) {
     return _hash<size_t>(str, len);
 }
 
 // хэш строки, выполняется в рантайме. Размер 32 бит
-uint32_t hash32(const char* str, int16_t len = -1) {
+inline uint32_t hash32(const char* str, int16_t len = -1) {
     return _hash<uint32_t>(str, len);
 }
 
 // хэш PROGMEM строки, выполняется в рантайме. Размер зависит от платформы и соответствует size_t
-size_t hash_P(PGM_P str, int16_t len = -1) {
+inline size_t hash_P(PGM_P str, int16_t len = -1) {
     return _hash_P<size_t>(str, len);
 }
 
 // хэш PROGMEM строки, выполняется в рантайме. Размер 32 бит
-uint32_t hash32_P(PGM_P str, int16_t len = -1) {
+inline uint32_t hash32_P(PGM_P str, int16_t len = -1) {
     return _hash_P<uint32_t>(str, len);
 }
 

--- a/src/utils/list.h
+++ b/src/utils/list.h
@@ -14,7 +14,7 @@ namespace list {
  * @param div символ-разделитель (умолч. ';')
  * @return uint16_t
  */
-uint16_t length(AnyText list, char div = ';') {
+inline uint16_t length(AnyText list, char div = ';') {
     if (!list.valid() || !list.length()) return 0;
     uint16_t am = 0;
     int16_t p = -1;
@@ -33,7 +33,7 @@ uint16_t length(AnyText list, char div = ';') {
  * @param div символ-разделитель (умолч. ';')
  * @return int16_t индекс в строке. -1 если не найдена
  */
-int16_t indexOf(AnyText list, AnyText str, char div = ';') {
+inline int16_t indexOf(AnyText list, AnyText str, char div = ';') {
     if (!list.valid() || !str.valid() || !list.length() || !str.length()) return -1;
     int16_t idx = 0;
     int16_t st = 0, end = -1;
@@ -60,7 +60,7 @@ int16_t indexOf(AnyText list, AnyText str, char div = ';') {
  * @return true содержит
  * @return false не содержит
  */
-bool includes(AnyText list, AnyText str, char div = ';') {
+inline bool includes(AnyText list, AnyText str, char div = ';') {
     return indexOf(list, str, div) >= 0;
 }
 
@@ -72,7 +72,7 @@ bool includes(AnyText list, AnyText str, char div = ';') {
  * @param div символ-разделитель (умолч. ';')
  * @return AnyText подстрока
  */
-AnyText get(AnyText list, uint16_t idx, char div = ';') {
+inline AnyText get(AnyText list, uint16_t idx, char div = ';') {
     if (!list.valid() || !list.length()) return AnyText();
     int16_t spos = 0, epos = -1;
     bool stop = 0;

--- a/src/utils/unicode.h
+++ b/src/utils/unicode.h
@@ -6,7 +6,7 @@
 namespace sutil::unicode {
 
 // декодировать строку с unicode символами. зарезервировать строку на длину len. Иначе - по длине строки
-String decode(const char* str, uint16_t len = 0) {
+inline String decode(const char* str, uint16_t len = 0) {
     String out;
     if (!len) len = strlen(str);
     out.reserve(len);
@@ -71,12 +71,12 @@ String decode(const char* str, uint16_t len = 0) {
 }
 
 // декодировать строку с unicode символами
-String decode(const String& str) {
+inline String decode(const String& str) {
     return decode(str.c_str(), str.length());
 }
 
 // кодировать unicode символ по его коду. В массиве должно быть 5 ячеек
-void encode(char* str, uint32_t c) {
+inline void encode(char* str, uint32_t c) {
     char b1 = 0, b2 = 0, b3 = 0, b4 = 0;
     if (c < 0x80) {
         b1 = (c & 0x7F) | 0x00;
@@ -101,7 +101,7 @@ void encode(char* str, uint32_t c) {
 }
 
 // кодировать unicode символ по его коду
-String encode(uint32_t code) {
+inline String encode(uint32_t code) {
     char sym[5];
     encode(sym, code);
     return sym;

--- a/src/utils/url.h
+++ b/src/utils/url.h
@@ -4,7 +4,7 @@
 namespace sutil::url {
 
 // символ должен быть urlencoded
-bool needsEncode(char c) {
+inline bool needsEncode(char c) {
     switch (c) {
         case '0' ... '9':
         case 'a' ... 'z':
@@ -21,7 +21,7 @@ bool needsEncode(char c) {
 }
 
 // закодировать в url
-void encode(const String& src, String& dest) {
+inline void encode(const String& src, String& dest) {
     dest.reserve(src.length());
     char c;
     for (uint16_t i = 0; i < src.length(); i++) {
@@ -37,18 +37,18 @@ void encode(const String& src, String& dest) {
 }
 
 // закодировать в url
-String encode(const String& src) {
+inline String encode(const String& src) {
     String dest;
     encode(src, dest);
     return dest;
 }
 
-uint8_t _decodeNibble(char c) {
+inline uint8_t _decodeNibble(char c) {
     return c - ((c <= '9') ? '0' : ((c <= 'F') ? 55 : 87));
 }
 
 // раскодировать url
-void decode(const String& src, String& dest) {
+inline void decode(const String& src, String& dest) {
     dest.reserve(src.length());
     for (uint16_t i = 0; i < src.length(); i++) {
         if (src[i] != '%') {
@@ -61,7 +61,7 @@ void decode(const String& src, String& dest) {
 }
 
 // раскодировать url
-String decode(const String& src) {
+inline String decode(const String& src) {
     String dest;
     decode(src, dest);
     return dest;


### PR DESCRIPTION
# Проблема  
С библиотекой StringUtils (версия 1.2.5) возникает ошибка линковки, при её использовании в классах, разделенных на заголовочный и обычный .cpp файл, что ограничивает возможность применения библиотеки в коде.  
Пример (проект на PlatformIO):    
[https://github.com/Georgiy10427/StringUtilPlayground](https://github.com/Georgiy10427/StringUtilPlayground)  
![Screenshot_20240110_213303_error](https://github.com/GyverLibs/StringUtils/assets/38399008/428b38d3-bf7b-4eb8-9c14-8ccd1aa3da63)  
# Решение  
Добавление inline к каждому методу (без принадлежности к какому-либо классу) в пространстве имён sutil решает проблему (см. код).  Если изменить в [примере](https://github.com/Georgiy10427/StringUtilPlayground) выше версию библиотеки на модифицированную, то это решит проблему.  
![screenshot_patched](https://github.com/GyverLibs/StringUtils/assets/38399008/6dd82273-76b9-45ce-9df4-a1c0add07fd6)
# О системе  
Версия ядра: v2.0.14 (последняя)  
Версия библиотеки: v1.2.5 (последняя)  

